### PR TITLE
Open Redirect

### DIFF
--- a/routes/redirect.ts
+++ b/routes/redirect.ts
@@ -13,7 +13,8 @@ const challenges = require('../data/datacache').challenges
 module.exports = function performRedirect () {
   return ({ query }: Request, res: Response, next: NextFunction) => {
     const toUrl = query.to
-    if (security.isRedirectAllowed(toUrl)) {
+    const isAllowed = security.redirectAllowlist.some((allowedUrl: string) => utils.startsWith(toUrl, allowedUrl))
+    if (isAllowed) {
       challengeUtils.solveIf(challenges.redirectCryptoCurrencyChallenge, () => { return toUrl === 'https://explorer.dash.org/address/Xr556RzuwX6hg5EGpkybbv5RanJoZN17kW' || toUrl === 'https://blockchain.info/address/1AbKfgvw9psQ41NbLi8kufDQTezwG8DRZm' || toUrl === 'https://etherscan.io/address/0x0f933ab9fcaaa782d0279c300d73750e1311eae6' })
       challengeUtils.solveIf(challenges.redirectChallenge, () => { return isUnintendedRedirect(toUrl as string) })
       res.redirect(toUrl as string)


### PR DESCRIPTION
The weakness was addressed by replacing the previous allowlist check with a more secure validation process. Instead of using a single call to security.isRedirectAllowed(toUrl), the code now explicitly iterates over a predefined allowlist (security.redirectAllowlist) and checks if the user provided URL starts with any allowed URL through the helper function utils.startsWith. This ensures that only URLs with approved prefixes are permitted, effectively preventing open redirect vulnerabilities by blocking untrusted or malicious URLs. As an additional consideration, it's important to review and carefully configure the allowlist to include only secure and necessary domains, and ensure that utils.startsWith correctly handles edge cases, such as URL encoding and trailing slashes.

Created by: plexicus@plexicus.com